### PR TITLE
Use of Java logging for queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ services:
 - docker
 
 stages:
+  # The 'compile' stage
+  # - Compiles the code.
+- name: compile
   # The 'build' stage
   # - Compiles the code and also used to run unit tests.
 - name: test
@@ -36,6 +39,12 @@ cache:
 
 matrix:
   include:
+
+ # Compile-stage jobs...
+
+  - stage: compile
+    name: Compile
+    script: scripts/compile.sh
 
   # Test-stage jobs...
 

--- a/fragnet-search/src/main/java/org/squonk/fragnet/Utils.java
+++ b/fragnet-search/src/main/java/org/squonk/fragnet/Utils.java
@@ -101,6 +101,8 @@ public class Utils {
      */
     public static File createLogfile(String filename) {
 
+        LOG.info("LOG_PATH=" + getLogPath());
+
         File queryLogFile = null;
         if (LOG_PATH != null) {
             File file = new File(LOG_PATH, filename);
@@ -123,6 +125,7 @@ public class Utils {
             LOG.warning("No user.home defined. Cannot create " + filename);
         }
         return queryLogFile;
+
     }
 
     public static void appendToFile(File file, String text) throws IOException {

--- a/fragnet-search/src/main/java/org/squonk/fragnet/Utils.java
+++ b/fragnet-search/src/main/java/org/squonk/fragnet/Utils.java
@@ -28,6 +28,7 @@ public class Utils {
 
     private static final Logger LOG = Logger.getLogger(Utils.class.getName());
     private static DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+    private static final String LOG_PATH;
 
     /**
      * Get a value that might be configured externally. Looks first for a system property
@@ -81,6 +82,17 @@ public class Utils {
     }
 
     /**
+     * Returns the configured LOG_PATH,
+     * which is either an environment variable (LOG_ROOT)
+     * or a property (user.home)
+     *
+     * @return A String, which may be NULL
+     */
+    public static String getLogPath() {
+        return LOG_PATH;
+    }
+
+    /**
      * Creates a logfile. The logfile is placed in the directory indicated
      * by the 'LOG_ROOT' environment variable or 'user.home' if that is not set.
      *
@@ -90,14 +102,8 @@ public class Utils {
     public static File createLogfile(String filename) {
 
         File queryLogFile = null;
-        LOG.info("Trying LOG_ROOT...");
-        String logPath = System.getenv("LOG_ROOT");
-        if (logPath == null) {
-            LOG.warning("No LOG_ROOT defined, trying user.home...");
-            logPath = System.getProperty("user.home");
-        }
-        if (logPath != null) {
-            File file = new File(logPath, filename);
+        if (LOG_PATH != null) {
+            File file = new File(LOG_PATH, filename);
             if (Utils.createFileIfNotPresent(file) == 1) {
                 try {
                     // test we can write to it
@@ -147,6 +153,14 @@ public class Utils {
             }
         }
         return 0;
+    }
+
+    static {
+        String logPath = System.getenv("LOG_ROOT");
+        if (logPath == null) {
+            logPath = System.getProperty("user.home");
+        }
+        LOG_PATH = logPath;
     }
 
 }

--- a/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
+++ b/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
@@ -45,7 +45,11 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
             }
             if (fh != null) {
                 // By default files are XML.
-                // Set to Simple (like the console)...
+                // Set to Simple (like the console) with the format
+                // that contains the date/time and the logging level like...
+                //
+                //   [2019-09-04 15:05:27] INFO    | OPENED
+                //
                 fh.setFormatter(new SimpleFormatter() {
                     private static final String format = "[%1$tF %1$tT] %2$-7s | %3$s %n";
                     @Override

--- a/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
+++ b/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
@@ -43,6 +43,7 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
             if (fh != null) {
                 LOG.info("Adding file handler (fileAndPath=" + fileAndPath + ")");
                 Q_LOG.addHandler(fh);
+                Q_LOG.info("OPENED");
             }
         } else {
             LOG.warning("queryLogFileName=" + queryLogFileName +
@@ -100,6 +101,7 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
     }
 
     protected void writeToQueryLog(String txt) {
+        LOG.info("QUERY | " + txt);
         Q_LOG.info(txt);
     }
 }

--- a/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
+++ b/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
@@ -18,11 +18,11 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
 
     private static final Logger LOG = Logger.getLogger(AbstractFragnetSearchRouteBuilder.class.getName());
 
-    // The Q_LOG is used to log query events
+    // The Q_LOG is used to log query events,
     // anonymous events that record queries that are conducted.
     // We expect this to be a size-limited set of files.
     private Logger Q_LOG;
-    private static final int LOG_FILE_SIZE = 64000;
+    private static final int LOG_FILE_SIZE = 1000000;
     private static final int LOG_FILE_COUNT = 10;
     private static final boolean LOG_FILE_APPEND = true;
 
@@ -51,7 +51,7 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
                 //   [2019-09-04 15:05:27] INFO    | OPENED
                 //
                 fh.setFormatter(new SimpleFormatter() {
-                    private static final String format = "[%1$tF %1$tT] %2$-7s | %3$s %n";
+                    private static final String format = "[%1$tF %1$tT] %2$-7s | %3$s%n";
                     @Override
                     public synchronized String format(LogRecord lr) {
                         return String.format(format,

--- a/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
+++ b/fragnet-search/src/main/java/org/squonk/fragnet/service/AbstractFragnetSearchRouteBuilder.java
@@ -8,12 +8,11 @@ import org.squonk.fragnet.chem.Calculator;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.logging.FileHandler;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 
 public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
 
@@ -22,12 +21,16 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
     // The Q_LOG is used to log query events
     // anonymous events that record queries that are conducted.
     // We expect this to be a size-limited set of files.
-    private static final Logger Q_LOG = Logger.getLogger("QueryLog");
+    private Logger Q_LOG;
     private static final int LOG_FILE_SIZE = 64000;
     private static final int LOG_FILE_COUNT = 10;
     private static final boolean LOG_FILE_APPEND = true;
 
     public AbstractFragnetSearchRouteBuilder(String queryLogFileName) {
+
+        Q_LOG = Logger.getLogger(queryLogFileName);
+        Q_LOG.setUseParentHandlers(false);
+
         String utilsLogPath = Utils.getLogPath();
         if (queryLogFileName != null && utilsLogPath != null) {
             String fileAndPath = utilsLogPath + '/' + queryLogFileName;
@@ -41,6 +44,18 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
                 LOG.severe("Failed to create FileHandler (" + e.getMessage() + ")");
             }
             if (fh != null) {
+                // By default files are XML.
+                // Set to Simple (like the console)...
+                fh.setFormatter(new SimpleFormatter() {
+                    private static final String format = "[%1$tF %1$tT] %2$-7s | %3$s %n";
+                    @Override
+                    public synchronized String format(LogRecord lr) {
+                        return String.format(format,
+                                             new Date(lr.getMillis()),
+                                             lr.getLevel().getLocalizedName(),
+                                             lr.getMessage());
+                    }
+                });
                 LOG.info("Adding file handler (fileAndPath=" + fileAndPath + ")");
                 Q_LOG.addHandler(fh);
                 Q_LOG.info("OPENED");
@@ -49,6 +64,7 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
             LOG.warning("queryLogFileName=" + queryLogFileName +
                         " getLogPath=" + utilsLogPath);
         }
+
     }
 
     protected String getUsername(Exchange exch) {
@@ -91,17 +107,12 @@ public abstract class AbstractFragnetSearchRouteBuilder extends RouteBuilder {
     }
 
     protected void writeToQueryLog(String user, String searchType, long executionTime, int nodes, int edges, int groups) {
-        String txt = String.format("%s\t%s\t%s\tnodes=%s,edges=%s,groups=%s\n", user, searchType, executionTime, nodes, edges, groups);
-        writeToQueryLog(txt);
+        String txt = String.format("%s\t%s\t%s\tnodes=%s,edges=%s,groups=%s", user, searchType, executionTime, nodes, edges, groups);
+        Q_LOG.info(txt);
     }
 
     protected void writeErrorToQueryLog(String user, String searchType, long executionTime, String msg) {
-        String txt = String.format("%s\t%s\t%s\terror=%s\n", user, searchType, executionTime, msg);
-        writeToQueryLog(txt);
-    }
-
-    protected void writeToQueryLog(String txt) {
-        LOG.info("QUERY | " + txt);
-        Q_LOG.info(txt);
+        String txt = String.format("%s\t%s\t%s\t%s", user, searchType, executionTime, msg);
+        Q_LOG.severe(txt);
     }
 }

--- a/orchestration/ansible/roles/fragnet/defaults/main.yaml
+++ b/orchestration/ansible/roles/fragnet/defaults/main.yaml
@@ -56,7 +56,7 @@ graph_pagecache_size_g: SetMe
 # Fragnet application variables...
 # -------
 
-# The Docker image tag for the 'squonk/fragnet-search' image.
+# The Docker image tag for the 'squonk/fragnet-all' image.
 fragnet_tag: latest
 # The port to expose the Fragnet service on.
 # Internally the port is expected to be on 8080,

--- a/orchestration/ansible/roles/fragnet/tasks/stop-fragnet-search.yaml
+++ b/orchestration/ansible/roles/fragnet/tasks/stop-fragnet-search.yaml
@@ -1,6 +1,6 @@
 ---
 
-- name: Stop (remove) fragnet-search
+- name: Stop (remove) fragnet container
   docker_container:
     name: fragnet-search
     state: absent

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# A script used by users and Travis.
+#
+# If you're a user then execute from the project root,
+# e.g. ./scripts/test.sh
+
+./gradlew assemble


### PR DESCRIPTION
- The change introduces the use of Java lofting with a FileHandler
- Query log files limited to 10 of approx 1MB
  i.e. `fragnet-queries-v2.log.0` and `fragnet-queries-v2.log.1`